### PR TITLE
Refactor for crime board using template

### DIFF
--- a/jira-automation/github.mjs
+++ b/jira-automation/github.mjs
@@ -14,6 +14,7 @@ export async function createGitHubIssue(repositoryId, issue, labels, labelsToAdd
         .filter(label => labels.find(l => l.name.toLowerCase() === label.toLowerCase()))
         .map(label => labels.find(l => l.name.toLowerCase() === label.toLowerCase()).id)
 
+    //NOTE: May need updating to only create if issue does not already exists.
     await graphqlWithAuth(
         `mutation CreateIssue($repository_id: ID!, $title: String!, $body: String!, $label_ids:[ID!]) {
           createIssue(

--- a/jira-automation/jira-to-github-processing.mjs
+++ b/jira-automation/jira-to-github-processing.mjs
@@ -86,8 +86,7 @@ export function jiraToGitHub({issueId, content}) {
     const impactOnTeams = extractImpactOnTeams(content)
 
     /**
-     * Some Crime content does not use template format so return actual content
-     * if crime ticket without the template format content then.
+     * Crime ticket without the template format content then use a default.
      */
     if (isCrimeIssue(issueId) && summary.length === 0) {
         return extractDescriptionForCrime(issueId, content)

--- a/jira-automation/jira-to-github-processing.mjs
+++ b/jira-automation/jira-to-github-processing.mjs
@@ -80,19 +80,20 @@ export function extractPrioritisationTotalScore(content) {
 
 
 export function jiraToGitHub({issueId, content}) {
-    /**
-     * Crime does not use template format so return actual content if crime ticket
-     * No need to extract various sections. Would be updated once standardised.
-     */
-    if (content && isCrimeIssue(issueId)) {
-        return extractDescriptionForCrime(issueId, content)
-    } else if (!content) {
-        return issueId;
-    }
 
     const summary = extractSummary(content)
     const intendedOutcome = extractIntendedOutcome(content)
     const impactOnTeams = extractImpactOnTeams(content)
+
+    /**
+     * Some Crime content does not use template format so return actual content if crime ticket
+     * No need to extract various sections. Would be updated once standardised.
+     */
+    if (isCrimeIssue(issueId) && summary.length === 0) {
+        return extractDescriptionForCrime(issueId, content)
+    } else if (!content) {
+        return issueId;
+    }
 
     return dedent(`${issueId}
     

--- a/jira-automation/jira-to-github-processing.mjs
+++ b/jira-automation/jira-to-github-processing.mjs
@@ -86,13 +86,11 @@ export function jiraToGitHub({issueId, content}) {
     const impactOnTeams = extractImpactOnTeams(content)
 
     /**
-     * Some Crime content does not use template format so return actual content if crime ticket
-     * No need to extract various sections. Would be updated once standardised.
+     * Some Crime content does not use template format so return actual content
+     * if crime ticket without the template format content then.
      */
     if (isCrimeIssue(issueId) && summary.length === 0) {
         return extractDescriptionForCrime(issueId, content)
-    } else if (!content) {
-        return issueId;
     }
 
     return dedent(`${issueId}

--- a/jira-automation/test/jira-to-github-processing.test.mjs
+++ b/jira-automation/test/jira-to-github-processing.test.mjs
@@ -91,12 +91,81 @@ const crime_issue = {
   }
 }
 
+const crime_issue_with_template = {
+  key: 'EI-321',
+  fields: {
+    summary: 'This is a summary',
+    description: `h3. Summary
+
+    Hourly Job to provide a CSV file in a storage account that has a count of all Virtual machines and VM scalesets that are running for the CJS Common Platform tenant by SKU type, Resource name, resource group name and Subscription name.
+    h3. Intended Outcome
+    
+    _Use data in CSV file format to review and understand how many SKu's are running every hours and especially at night so an average can be used to purchase the desired RI's for CFT._
+    
+    _This should cover both virtual machines and scale sets._
+    
+    _Every hour should have a new CSV file_
+    h3. Impact on Teams
+    
+    _No impact_
+    h3. Additional information
+    
+    _The below query was created by Ben for Scale set and might be a good start:_
+    
+    
+    {code:java}
+    // CFT-Scalesets
+    // CFT total scale set vm's
+    // Click the "Run query" command above to execute the query and see results.
+    resources
+    | join kind=inner (
+        resourcecontainers
+        | where type == 'microsoft.resources/subscriptions'
+        | project subscriptionId, subscriptionName = name)
+        on subscriptionId
+    | where type=~ 'microsoft.compute/virtualmachinescalesets'
+    | project subscriptionName, name, location, resourceGroup, Capacity = toint(sku.capacity), Tier = tostring(sku.name)
+    | summarize Total = sum(Capacity) by Tier, subscriptionName
+    | order by Tier desc
+    {code}
+    
+    
+    Add a management lifecycle policy that removes data after 90 days (confirm the number with Bruce).
+    
+    It's expected the easiest way to run this will be a Kubernetes CronJob that writes to a storage account (might be able to use the existing [finopsdataptlsa|https://portal.azure.com/#@HMCTS.NET/resource/subscriptions/1baf5470-1c3e-40d3-a6f7-74bfbce4b348/resourceGroups/finopsdataptlrg/providers/Microsoft.Storage/storageAccounts/finopsdataptlsa] account)
+    
+    
+    
+    _Bruce will be using this hourly SKU data and ingesting it into PowerBI to give us a average view of all SKU's_
+    h3. Prioritisation Matrix
+    |*Value / benefit dimension*|*Weighting*|*Score*|
+    |Is this a mandatory or legislative change|Mandatory / Legislative 100, No 0|0|
+    |Does this fix a security risk|Critical 100, High 30, Medium 20, Low 5, Info 0, none 0|0|
+    |Vendor support or PlatOps support impact|Vendor 25,  PlatOps 10, No 0|0|
+    |Will the application cease to work without this work|Fully 25, Partially 10, No 0|0|
+    |When does this need to be delivered by|Immediately 20, Within 2 months 15, within 4 months 10, within 6 months 5, more than 6 months 0|15|
+    |Are other systems dependent upon this change|Multiple 10, One 5, No 0|0|
+    |Is this strategic or tactical|Strategic 10, Tactical 0|10|
+    |Size of change
+    (xs = 1 person 1 sprint, s = 1 person 2 sprints or 2 people 1 sprint etc.)|XL = 0, Large 5, Medium 10, Small 15, XS = 20|20|
+    |What is the priority of this work within your area|High 5, Medium 2, Low 0|2|
+    |How big are the benefits for this piece of work|High 20, Medium 10, Low 5|20|
+    |How big are the *(Annual)* cost savings or avoidance for this piece of work|<=£500k (per annum) 100, <=£250k 75, <=£100k 50, <=£50k 40, 0
+    (1 squad 1 sprint = 35K)|50|
+    |User quality of life improvement? (Engineers and/or End Users)|End User & Engineer 15, End User impact 10, Engineers 5, No impact 0|0|
+    |High Availability Improvement?|High 75, Medium 50, Low 25, None 0|0|
+    |Path to Live Improvement?|Major 75, Minor 25, None 0|0|
+    
+    Total: 118`
+  }
+}
+
 describe('jira-to-github-processing for CNP', t => {
   it('extracts summary from Jira issue', t => {
 
     const result = extractSummary(cnp_issue.fields.description)
 
-    assert.equal(result, 'Hourly Job to provide a CSV file in a storage account that has a count of all Virtual machines and VM scalesets that are running  for the CJS Common Platform tenant by SKU type, Resource name, resource group name and Subscription name.')
+    assert.equal(result, 'Hourly Job to provide a CSV file in a storage account that has a count of all Virtual machines and VM scalesets that are running for the CJS Common Platform tenant by SKU type, Resource name, resource group name and Subscription name.')
   })
 
   it('extracts intended outcome from Jira issue', t => {
@@ -113,22 +182,22 @@ describe('jira-to-github-processing for CNP', t => {
     })
 
     assert.equal(result, `DTSPO-123
-    
-    ## Summary
 
-    Hourly Job to provide a CSV file in a storage account that has a count of all Virtual machines and VM scalesets that are running for the CJS Common Platform tenant by SKU type, Resource name, resource group name and Subscription name.
+## Summary
 
-    ## Intended Outcome
+Hourly Job to provide a CSV file in a storage account that has a count of all Virtual machines and VM scalesets that are running for the CJS Common Platform tenant by SKU type, Resource name, resource group name and Subscription name.
 
-    *Use data in CSV file format to review and understand how many SKu's are running every hours and especially at night so an average can be used to purchase the desired RI's for CFT.*
-    
-    *This should cover both virtual machines and scale sets.*
-    
-    *Every hour should have a new CSV file*
+## Intended Outcome
 
-    ## Impact on Teams
+*Use data in CSV file format to review and understand how many SKu's are running every hours and especially at night so an average can be used to purchase the desired RI's for CFT.*
 
-    *No impact*`)
+*This should cover both virtual machines and scale sets.*
+
+*Every hour should have a new CSV file*
+
+## Impact on Teams
+
+*No impact*`)
   })
 
   it('extracts score from Jira issue', t => {
@@ -140,7 +209,7 @@ describe('jira-to-github-processing for CNP', t => {
 })
 
 describe('jira-to-github-processing for CRIME', t => {
-  describe('crime not using template format', t => {
+  describe('Crime not using template format', t => {
     it('should not extract summary from Jira issue', t => {
 
       const result = extractSummary(crime_issue.fields.description)
@@ -168,6 +237,53 @@ describe('jira-to-github-processing for CRIME', t => {
       const score = extractPrioritisationTotalScore(crime_issue.fields.description)
 
       assert.equal(score, 0, 'Prioritisation score in not accurate')
+    })
+  })
+
+  describe('Crime using template format', t => {
+    it('should extract summary from Jira issue', t => {
+
+      const result = extractSummary(crime_issue_with_template.fields.description)
+
+      assert.notStrictEqual(result, 'Hourly Job to provide a CSV file in a storage account that has a count of all Virtual machines and VM scalesets that are running  for the CJS Common Platform tenant by SKU type, Resource name, resource group name and Subscription name.')
+    })
+
+    it('should extract intended outcome from Jira issue', t => {
+
+      const result = extractIntendedOutcome(crime_issue_with_template.fields.description)
+
+      assert.equal(result, `*Use data in CSV file format to review and understand how many SKu's are running every hours and especially at night so an average can be used to purchase the desired RI's for CFT.*\n    \n    *This should cover both virtual machines and scale sets.*\n    \n    *Every hour should have a new CSV file*`)
+    })
+
+    it('should convert jira description template to github markdown', t => {
+      const result = jiraToGitHub({
+        issueId: crime_issue_with_template.key,
+        content: crime_issue_with_template.fields.description
+      })
+
+      assert.equal(result, `EI-321
+
+## Summary
+
+Hourly Job to provide a CSV file in a storage account that has a count of all Virtual machines and VM scalesets that are running for the CJS Common Platform tenant by SKU type, Resource name, resource group name and Subscription name.
+
+## Intended Outcome
+
+*Use data in CSV file format to review and understand how many SKu's are running every hours and especially at night so an average can be used to purchase the desired RI's for CFT.*
+
+*This should cover both virtual machines and scale sets.*
+
+*Every hour should have a new CSV file*
+
+## Impact on Teams
+
+*No impact*`)
+    })
+
+    it('should extract score from Jira issue', t => {
+      const score = extractPrioritisationTotalScore(crime_issue_with_template.fields.description)
+
+      assert.equal(score, 118, 'Prioritisation score in not accurate')
     })
   })
 })


### PR DESCRIPTION
### Change description
The issues on the Crime `EI` devops board now uses the scoring matrix when new issues are created.

Updated to code to cater for this and enable it pick up the template content when creating jira issue on the github board.
